### PR TITLE
fix(typo): Github -> GitHub

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -22,7 +22,7 @@ export function Footer() {
             target="_blank"
           >
             <span></span>
-            Github
+            GitHub
           </Link>
         </div>
         <div>


### PR DESCRIPTION
GitHub の `H` は大文字なので、フッターを修正しました。