### PR TITLE
サイドメニューの活動履歴のリンクを /activity から /history に変更

### DIFF
--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -74,7 +74,7 @@ export default async function Page({ params }: PageProps) {
           <div></div>
         )}
 
-        <Link href="/activity" passHref>
+        <Link href="/history" passHref>
           一覧に戻る
         </Link>
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -130,13 +130,13 @@ export function Header() {
                   </div>
                 </Link>
                 <Link
-                  href="/activity"
+                  href="/history"
                   className="w-full h-11 flex gap-2 flex-wrap"
                   onClick={handleLinkClick}
                 >
                   <div className="gradient w-1"></div>
                   <div className="w-[calc(100%-12px)] flex items-center">
-                    <div>最近の活動</div>
+                    <div>プロジェクトの歴史</div>
                   </div>
                 </Link>
               </div>


### PR DESCRIPTION
関連Issue：#9