### PR TITLE
SNSへのシェアボタンを設置する

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,39 @@
+This project includes the following third-party libraries:
+
+---
+
+framer-motion (MIT License)
+Copyright (c) 2018 Framer B.V.
+[https://github.com/framer/motion](https://github.com/framer/motion)
+
+---
+
+react-share (MIT License)
+Copyright (c) 2016 Kent Nygard
+[https://github.com/nygardk/react-share](https://github.com/nygardk/react-share)
+
+---
+
+The above libraries are used under the MIT License.
+
+---
+
+MIT License
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react'
 import Link from 'next/link'
+import SNSSharePanel from './SNSSharePanel';
 import { usePathname } from 'next/navigation'
 import {
   Drawer,
@@ -51,6 +52,7 @@ export function Header() {
               </Link>
             </div>
           )}
+          <SNSSharePanel className="mr-4" />
           <Drawer direction="right" open={open} onOpenChange={setOpen}>
             <DrawerTrigger asChild>
               <Button className="cursor-pointer w-11 h-11">

--- a/components/SNSSharePanel.tsx
+++ b/components/SNSSharePanel.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { useState } from "react";
+import {
+  TwitterShareButton,
+  FacebookShareButton,
+  LineShareButton,
+  HatenaShareButton,
+  XIcon,
+  FacebookIcon,
+  LineIcon,
+  HatenaIcon,
+} from "react-share";
+
+import { motion, AnimatePresence } from "framer-motion";
+
+const shareUrl = "https://dd2030.org/";
+const shareTitle = "デジタル民主主義2030プロジェクトポータルサイト";
+
+const SNSButtons = () => (
+  <>
+    <HatenaShareButton url={shareUrl} title={shareTitle}>
+      <HatenaIcon size={32} round />
+    </HatenaShareButton>
+    <LineShareButton url={shareUrl} title={shareTitle}>
+      <LineIcon size={32} round />
+    </LineShareButton>
+    <FacebookShareButton url={shareUrl}>
+      <FacebookIcon size={32} round />
+    </FacebookShareButton>
+    <TwitterShareButton url={shareUrl} title={shareTitle}>
+      <XIcon size={32} round />
+    </TwitterShareButton>
+  </>
+);
+
+export default function SNSSharePanel({ className = "" }: { className?: string }) {
+  const [visible, setVisible] = useState(false);
+
+  return (
+    <div className={`relative flex items-center gap-2 ${className}`}>
+      {/* SNSボタン：PC表示（横） */}
+      <AnimatePresence>
+        {visible && (
+          <motion.div
+            className="hidden sm:flex gap-3 mr-1"
+            initial={{ opacity: 0, x: 10 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: 10 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+          >
+            <SNSButtons />
+          </motion.div>
+        )}
+      </AnimatePresence>
+
+      {/* SHAREボタン */}
+      <button
+        className={`text-sm font-normal px-3 py-0.5 rounded-none transition z-10
+        ${visible
+          ? "bg-white text-black border border-black"
+          : "bg-black text-white border border-black hover:bg-gray-700 hover:text-white"
+        }`}
+        onClick={() => setVisible((v) => !v)}
+      >
+        SHARE
+      </button>
+
+      {/* SNSボタン：スマホ表示（下に表示） */}
+      <AnimatePresence>
+        {visible && (
+          <motion.div
+            className="sm:hidden absolute top-full mt-2 right-0 flex gap-2"
+            initial={{ opacity: 0, y: -10 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -10 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+          >
+            <SNSButtons />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </div>
+  );
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "postcss": "^8.5.3",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-share": "^5.2.2",
         "reading-time": "^1.5.0",
         "rehype-pretty-code": "^0.14.1",
         "sharp": "^0.34.1",
@@ -4383,6 +4384,12 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==",
+      "license": "MIT"
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -6856,6 +6863,29 @@
         "json5": "lib/cli.js"
       }
     },
+    "node_modules/jsonp": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/jsonp/-/jsonp-0.2.1.tgz",
+      "integrity": "sha512-pfog5gdDxPdV4eP7Kg87M8/bHgshlZ5pybl+yKxAnCZ5O7lCIn7Ixydj03wOlnDQesky2BPyA91SQ+5Y/mNwzw==",
+      "dependencies": {
+        "debug": "^2.1.3"
+      }
+    },
+    "node_modules/jsonp/node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
+      }
+    },
+    "node_modules/jsonp/node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
     "node_modules/jsx-ast-utils": {
       "version": "3.3.5",
       "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.3.5.tgz",
@@ -8751,6 +8781,19 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-share": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/react-share/-/react-share-5.2.2.tgz",
+      "integrity": "sha512-z0nbOX6X6vHHWAvXduNkYeJUKTKNpKM5Xpmc5a2BxjJhUWl+sE7AsSEMmYEUj2DuDjZr5m7KFIGF0sQPKcUN6w==",
+      "license": "MIT",
+      "dependencies": {
+        "classnames": "^2.3.2",
+        "jsonp": "^0.2.1"
+      },
+      "peerDependencies": {
+        "react": "^17 || ^18 || ^19"
       }
     },
     "node_modules/react-style-singleton": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@tailwindcss/postcss": "^4.1.3",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^12.11.4",
         "github-markdown-css": "^5.8.1",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.488.0",
@@ -5715,6 +5716,33 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.11.4",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.11.4.tgz",
+      "integrity": "sha512-kyE5oWZCUxhDb7LtpEyyadNThJJvoE8a6bfUTBqz++zw3XxDOosPAvw1lqNhYbjOgy57YuAlJ5qG/Cx5BigiEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.11.4",
+        "motion-utils": "^12.9.4",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -8103,6 +8131,21 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.11.4",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.11.4.tgz",
+      "integrity": "sha512-1z/qYsrDjSx5QjOH8GfJ2RfFBvEzI2gdAEt2zNW+f7QkLlqjM3sQieESJr5+QtVmvD81qPANM7t97ROixKIt9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.9.4"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.9.4",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.9.4.tgz",
+      "integrity": "sha512-BW3I65zeM76CMsfh3kHid9ansEJk9Qvl+K5cu4DVHKGsI52n76OJ4z2CUJUV+Mn3uEP9k1JJA3tClG0ggSrRcg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "postcss": "^8.5.3",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-share": "^5.2.2",
     "reading-time": "^1.5.0",
     "rehype-pretty-code": "^0.14.1",
     "sharp": "^0.34.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/postcss": "^4.1.3",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "framer-motion": "^12.11.4",
     "github-markdown-css": "^5.8.1",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.488.0",


### PR DESCRIPTION
## 概要
Issue #80 を実装するために、SNSへのシェアボタンを追加しました。

## 変更内容
- SHAREボタンの追加と、押下時にSNSボタン（X、Facebook、LINE、はてブ）が展開される実装
- SNSボタンの表示にはアニメーションを追加（framer-motionを使用）
- モバイル画面で幅が小さい場合は、SNSボタンが下方向に表示
- 使用ライブラリ（react-share, framer-motion）のライセンス情報を `NOTICE` ファイルとして追加

## 備考
- SNSボタンに使用しているアイコンは、react-share が提供するアイコンを使用しています。

## スクショ
- 初期状態
![image](https://github.com/user-attachments/assets/0c63bd25-cc26-45ad-a1b3-a9a1f50428b4)

- 押して展開時
![image](https://github.com/user-attachments/assets/225ef3d9-6552-4b11-ae4e-1664e825e18b)