### PR TITLE
Fix CSS and image loading on top and history pages in PR preview

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from 'next'
 import { Header } from '@/components/Header'
 import { Footer } from '@/components/Footer'
-import './global.css'
-import './content.css'
 import { biz_udGothic400, inter } from '@/lib/fonts'
+import { CssLoader } from '../components/CssLoader'
 
 export const metadata: Metadata = {
   title: 'デジタル民主主義2030',
@@ -87,6 +86,8 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       ],
     },
   ]
+
+
   return (
     <html
       lang="ja"
@@ -99,6 +100,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
         />
+        <CssLoader />
         <Header />
         <main>
           <div className="max-w-7xl mx-auto px-4 py-6">{children}</div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -36,7 +36,7 @@ export default async function Page() {
             </div>
           </hgroup>
           <Image
-            src="/home__3project__kouchou-ai.webp"
+            src={process.env.NEXT_PUBLIC_PR_NUMBER ? `/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}/home__3project__kouchou-ai.webp` : '/home__3project__kouchou-ai.webp'}
             width={576}
             height={262.8}
             alt="広聴AIのイメージ画像"
@@ -73,7 +73,7 @@ export default async function Page() {
             </div>
           </hgroup>
           <Image
-            src="/home__3project__idobata.webp"
+            src={process.env.NEXT_PUBLIC_PR_NUMBER ? `/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}/home__3project__idobata.webp` : '/home__3project__idobata.webp'}
             width={576}
             height={324.89}
             alt="いどばたのイメージ画像"
@@ -108,7 +108,7 @@ export default async function Page() {
             </div>
           </hgroup>
           <Image
-            src="/home__3project__polimoney.webp"
+            src={process.env.NEXT_PUBLIC_PR_NUMBER ? `/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}/home__3project__polimoney.webp` : '/home__3project__polimoney.webp'}
             width={576}
             height={315}
             alt="Polimoneyのイメージ画像"

--- a/components/CssLoader.tsx
+++ b/components/CssLoader.tsx
@@ -1,0 +1,20 @@
+'use client'
+
+import { useEffect } from 'react'
+
+export function CssLoader() {
+  useEffect(() => {
+    const loadCSS = (path: string) => {
+      const link = document.createElement('link')
+      link.rel = 'stylesheet'
+      link.href = path
+      document.head.appendChild(link)
+    }
+    
+    const basePath = process.env.NEXT_PUBLIC_PR_NUMBER ? `/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}` : ''
+    loadCSS(`${basePath}/global.css`)
+    loadCSS(`${basePath}/content.css`)
+  }, [])
+
+  return null
+}

--- a/lib/image-loader.ts
+++ b/lib/image-loader.ts
@@ -1,0 +1,8 @@
+export default function imageLoader({ src, _width, _quality }: { src: string; _width: number; _quality?: number }) {
+  if (src.startsWith('http') || (process.env.NEXT_PUBLIC_PR_NUMBER && src.startsWith(`/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}`))) {
+    return src
+  }
+  
+  const basePath = process.env.NEXT_PUBLIC_PR_NUMBER ? `/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}` : ''
+  return `${basePath}${src}`
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -4,6 +4,8 @@ const nextConfig: NextConfig = {
   // Enable static image imports for Next.js Image component
   images: {
     unoptimized: true,
+    loader: 'custom',
+    loaderFile: './lib/image-loader.ts',
   },
   // Add trailingSlash for better compatibility with static file serving
   trailingSlash: true,


### PR DESCRIPTION
# Fix CSS and image loading on top and history pages in PR preview

トップページとhistoryページのPRプレビューでCSSや画像がロードされない問題を修正しました。

## 変更内容
- トップページの画像参照を`basePath`対応に修正
- CSSの読み込みを動的に行い`basePath`を考慮するように変更
- カスタムイメージローダーを追加して画像パスの解決を改善

この変更により、PRプレビュー環境でもトップページとhistoryページのCSSと画像が正しく表示されるようになります。

## テスト結果
- ローカルで`NEXT_PUBLIC_PR_NUMBER=test npm run build`を実行し、ビルドが正常に完了することを確認しました
- 静的エクスポートが正しく生成され、トップページとhistoryページが含まれていることを確認しました

Link to Devin run: https://app.devin.ai/sessions/150211bb7b2c456c83fde7a0385003f0
User: NISHIO Hirokazu
