### PR TITLE
Fix duplicate 'history' in URL paths causing 404 errors

### DIFF
--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -156,9 +156,9 @@ function generateNavigationLinks(currentSlug: string): {
           const prevDirPath = path.join(historyDir, prevDir)
           
           if (fileBase === 'slack' && fs.existsSync(path.join(prevDirPath, 'slack.md'))) {
-            result.prev = `history/${prevDir}/slack`
+            result.prev = `${prevDir}/slack`
           } else if (fs.existsSync(path.join(prevDirPath, `${fileBase}.md`))) {
-            result.prev = `history/${prevDir}/${fileBase}`
+            result.prev = `${prevDir}/${fileBase}`
           }
         }
         
@@ -172,9 +172,9 @@ function generateNavigationLinks(currentSlug: string): {
           const nextDirPath = path.join(historyDir, nextDir)
           
           if (fileBase === 'slack' && fs.existsSync(path.join(nextDirPath, 'slack.md'))) {
-            result.next = `history/${nextDir}/slack`
+            result.next = `${nextDir}/slack`
           } else if (fs.existsSync(path.join(nextDirPath, `${fileBase}.md`))) {
-            result.next = `history/${nextDir}/${fileBase}`
+            result.next = `${nextDir}/${fileBase}`
           }
         }
       }

--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -44,7 +44,8 @@ export default async function Page({ params }: PageProps) {
   const slug = (await params).slug
   let filePath = ''
   
-  const parts = slug.split('/')
+  const cleanSlug = slug.endsWith('/') ? slug.slice(0, -1) : slug
+  const parts = cleanSlug.split('/')
   if (parts.length >= 2) {
     const weekDir = parts[0]
     const fileBase = parts[1]

--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateStaticParams() {
       
       weekFiles.forEach(file => {
         if (file.endsWith('.md')) {
-          const slug = `history/${weekDir}/${file.replace(/\.md$/, '')}`
+          const slug = `${weekDir}/${file.replace(/\.md$/, '')}`
           slugs.push({ slug })
         }
       })

--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -77,7 +77,7 @@ export default async function Page({ params }: PageProps) {
       <div className="mt-2 mb-1 flex justify-center items-center gap-4">
         {navigation.prev ? (
           <Link
-            href={`/history/${navigation.prev}`}
+            href={`/history/${navigation.prev}/`}
             passHref
             className={`${buttonVariants()} h-11`}
           >
@@ -95,7 +95,7 @@ export default async function Page({ params }: PageProps) {
 
         {navigation.next ? (
           <Link
-            href={`/history/${navigation.next}`}
+            href={`/history/${navigation.next}/`}
             passHref
             className={`${buttonVariants()} h-11`}
           >

--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -24,7 +24,7 @@ export async function generateStaticParams() {
       
       weekFiles.forEach(file => {
         if (file.endsWith('.md')) {
-          const slug = `${weekDir}/${file.replace(/\.md$/, '')}`
+          const slug = `${weekDir}/${file.replace(/\.md$/, '')}/`
           slugs.push({ slug })
         }
       })

--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -125,7 +125,8 @@ function generateNavigationLinks(currentSlug: string): {
   const markdownDir = path.join(process.cwd(), 'markdown')
   const historyDir = path.join(markdownDir, 'history')
 
-  const parts = currentSlug.split('/')
+  const cleanSlug = currentSlug.endsWith('/') ? currentSlug.slice(0, -1) : currentSlug
+  const parts = cleanSlug.split('/')
   if (parts.length >= 2) {
     const weekDir = parts[0] // week1_20250404
     const fileBase = parts[1] // slack または project

--- a/app/history/[slug]/page.tsx
+++ b/app/history/[slug]/page.tsx
@@ -45,9 +45,9 @@ export default async function Page({ params }: PageProps) {
   let filePath = ''
   
   const parts = slug.split('/')
-  if (parts.length >= 3) {
-    const weekDir = parts[1]
-    const fileBase = parts[2]
+  if (parts.length >= 2) {
+    const weekDir = parts[0]
+    const fileBase = parts[1]
     filePath = path.join(process.cwd(), 'markdown', 'history', weekDir, `${fileBase}.md`)
   }
 
@@ -125,9 +125,9 @@ function generateNavigationLinks(currentSlug: string): {
   const historyDir = path.join(markdownDir, 'history')
 
   const parts = currentSlug.split('/')
-  if (parts.length >= 3) {
-    const weekDir = parts[1] // week1_20250404
-    const fileBase = parts[2] // slack または project
+  if (parts.length >= 2) {
+    const weekDir = parts[0] // week1_20250404
+    const fileBase = parts[1] // slack または project
     
     const weekMatch = weekDir.match(/week(\d+)_/)
     if (weekMatch) {

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -58,7 +58,7 @@ export default async function Page() {
     }
 
     if (weekFiles.includes('slack.md')) {
-      weeklyActivities[week].slack.push(`history/${weekDir}/slack`)
+      weeklyActivities[week].slack.push(`${weekDir}/slack`)
     }
 
     weekFiles.forEach((file: string) => {
@@ -69,7 +69,7 @@ export default async function Page() {
           weeklyActivities[week].github[project] = []
         }
         
-        weeklyActivities[week].github[project].push(`history/${weekDir}/${project}`)
+        weeklyActivities[week].github[project].push(`${weekDir}/${project}`)
       }
     })
   })

--- a/next.config.ts
+++ b/next.config.ts
@@ -12,8 +12,8 @@ const nextConfig: NextConfig = {
   },
   output: 'export',
   distDir: 'out',
-  skipTrailingSlashRedirect: true,
-  skipMiddlewareUrlNormalize: true,
+  // skipTrailingSlashRedirect: true,
+  // skipMiddlewareUrlNormalize: true,
   basePath: process.env.NEXT_PUBLIC_PR_NUMBER ? `/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}` : '',
 }
 


### PR DESCRIPTION
# URLパスの重複「history」を修正

## 問題
URLパスに「history」が二重に含まれているため、以下のようなURLが404エラーになっていました：
- `/history/history/week1_20250319/slack`
- `/history/history/week8_20250507/slack`

## 修正内容
1. `app/history/page.tsx`でリンク生成時の重複する「history/」を削除
2. `app/history/[slug]/page.tsx`でスラグのパース処理を修正
3. `app/history/[slug]/page.tsx`でナビゲーションリンクの生成を修正
4. `app/history/[slug]/page.tsx`でスラグの末尾のスラッシュを処理するロジックを追加
5. `next.config.ts`のルーティング設定を調整

これにより、正しいURLパス（例：`/history/week1_20250319/slack`）でページが表示されるようになります。

## Link to Devin run
https://app.devin.ai/sessions/1cc73600b90047839846e4df04181bcc

## Requested by
NISHIO Hirokazu (nishio.hirokazu@gmail.com)
