### PR TITLE
Fix routing for history pages

### DIFF
--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -58,7 +58,7 @@ export default async function Page() {
     }
 
     if (weekFiles.includes('slack.md')) {
-      weeklyActivities[week].slack.push(`history/${weekDir}/slack`)
+      weeklyActivities[week].slack.push(`${weekDir}/slack`)
     }
 
     weekFiles.forEach((file: string) => {
@@ -69,7 +69,7 @@ export default async function Page() {
           weeklyActivities[week].github[project] = []
         }
         
-        weeklyActivities[week].github[project].push(`history/${weekDir}/${project}`)
+        weeklyActivities[week].github[project].push(`${weekDir}/${project}`)
       }
     })
   })


### PR DESCRIPTION
## 問題
/history 系ページが404になる

## 修正の概要
- URL内で /history が重複する
- slug はnextの仕様で1階層分しか受け取れないので、array で複数階層指定できるように変更

## 動作確認結果
<img width="1029" alt="image" src="https://github.com/user-attachments/assets/ec28a7aa-0978-40b1-ba75-020121980918" />

## 備考
local だと out/* と .next/* の2フォルダを消すまで、 `npm run dev` したときに修正前のページのURLを読み込もうとしてエラーになり、サーバ起動に失敗していました。Production モードでも発生する問題なのか調査できていませんが、念の為記載します。