### PR TITLE
広聴AIページに使い方ボタンを作成/Googleフォームのリンク貼り替え

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,6 +3,8 @@ import fs from 'fs'
 import { marked } from 'marked'
 import { Markdown } from '@/components/Markdown'
 import { CoCreation } from '@/components/CoCreation'
+import { TopScrollButton } from '@/components/TopScrollButton'
+
 
 export default async function Page() {
   const filePath = path.join(process.cwd(), 'markdown', 'about.md')
@@ -25,6 +27,9 @@ export default async function Page() {
       />
       <Markdown content={content} />
       <CoCreation />
+            {/* トップに戻るボタン */}
+            <TopScrollButton />
+      
     </div>
   )
 }

--- a/app/co-creation/page.tsx
+++ b/app/co-creation/page.tsx
@@ -14,7 +14,7 @@ export default async function Page() {
           </p>
           <p className="mt-4">下のGoogleフォームよりご連絡下さい。 </p>
           <Link
-            href="https://docs.google.com/forms/d/e/1FAIpQLSdAJojxjpIJnOMtydYTOhtsTkkKgDS22R-iHYDVMstYd2RUBA/viewform"
+            href="https://docs.google.com/forms/d/e/1FAIpQLScytDD9cdYwcl_Gsr0qal-Op7mpXaQzK3KGTk_FsahY5FkU9w/viewform?usp=header"
             className={`${buttonVariants()} h-11 mt-4`}
             target="_blank"
           >

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -4,6 +4,8 @@ import Link from 'next/link'
 import { buttonVariants } from '@/components/ui/button'
 import { marked } from 'marked'
 import { Markdown } from '@/components/Markdown'
+import { TopScrollButton } from '@/components/TopScrollButton'
+
 
 export default async function Page() {
   const markdownDir = path.join(process.cwd(), 'markdown')
@@ -120,6 +122,8 @@ export default async function Page() {
         </section >
       ))
       }
+      {/* トップに戻るボタン */}
+      <TopScrollButton />
 
 
     </section >

--- a/app/idobata/page.tsx
+++ b/app/idobata/page.tsx
@@ -4,12 +4,27 @@ import Image from 'next/image'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 import GitHubIcon from '@mui/icons-material/GitHub'
 import { CoCreation } from '@/components/CoCreation'
+import { TopScrollButton } from '@/components/TopScrollButton'
+
 export default async function Page() {
   return (
     <div>
       <section className="mx-auto max-w-xl mt-10">
         <hgroup>
           <h2 className="text-3xl">いどばた</h2>
+          <div className="flex gap-4 mt-20">
+            {/* <Link href="https://github.com/digitaldemocracy2030/idobata/blob/main/README.md" className={`${buttonVariants()} h-11`}>
+              <span></span>
+              使い方を見てみる
+              <NavigateNextIcon />
+            </Link> */}
+            {/* <Link href="" className={`${buttonVariants()} h-11`}>
+              <span></span>
+              実際に使ってみる
+              <NavigateNextIcon />
+            </Link> */}
+          </div>
+          <div className="my-8" />
           <p className="font-bold mt-2">
             民意による政策反映：デジタル上で大規模熟議が可能なプラットフォームの構築
           </p>
@@ -64,6 +79,9 @@ export default async function Page() {
         </div>
       </section>
       <CoCreation />
+      {/* トップに戻るボタン */}
+      <TopScrollButton />
+
     </div>
   )
 }

--- a/app/kouchou-ai/page.tsx
+++ b/app/kouchou-ai/page.tsx
@@ -4,12 +4,27 @@ import Image from 'next/image'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 import GitHubIcon from '@mui/icons-material/GitHub'
 import { CoCreation } from '@/components/CoCreation'
+import { TopScrollButton } from '@/components/TopScrollButton'
+
 export default async function Page() {
   return (
     <div>
       <section className="mx-auto max-w-xl mt-10">
         <hgroup>
           <h2 className="text-3xl">広聴AI</h2>
+          <div className="flex gap-4 mt-20">
+            <Link href="https://github.com/digitaldemocracy2030/kouchou-ai/tree/main/how_to_use" className={`${buttonVariants()} h-11`}>
+              <span></span>
+              使い方を見てみる
+              <NavigateNextIcon />
+            </Link>
+            {/* <Link href="" className={`${buttonVariants()} h-11`}>
+              <span></span>
+              実際に使ってみる
+              <NavigateNextIcon />
+            </Link> */}
+          </div>
+          <div className="my-8" />
           <p className="font-bold mt-2">
             ブロードリスニングのさらなる進展： Talk to the Cityの実用化
           </p>
@@ -99,6 +114,8 @@ export default async function Page() {
         </div>
       </section>
       <CoCreation />
+      {/* トップに戻るボタン */}
+      <TopScrollButton />
     </div>
   )
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,6 +3,8 @@ import { buttonVariants } from '@/components/ui/button'
 import Image from 'next/image'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 import { CoCreation } from '@/components/CoCreation'
+import { TopScrollButton } from '@/components/TopScrollButton'
+
 export default async function Page() {
   return (
     <div>
@@ -134,6 +136,9 @@ export default async function Page() {
         </section>
       </section>
       <CoCreation />
+      {/* トップに戻るボタン */}
+      <TopScrollButton />
+
     </div>
   )
 }

--- a/app/polimoney/page.tsx
+++ b/app/polimoney/page.tsx
@@ -4,6 +4,8 @@ import Image from 'next/image'
 import NavigateNextIcon from '@mui/icons-material/NavigateNext'
 import GitHubIcon from '@mui/icons-material/GitHub'
 import { CoCreation } from '@/components/CoCreation'
+import { TopScrollButton } from '@/components/TopScrollButton'
+
 export default async function Page() {
   return (
     <div>
@@ -60,6 +62,9 @@ export default async function Page() {
         </div>
       </section>
       <CoCreation />
+            {/* トップに戻るボタン */}
+            <TopScrollButton />
+      
     </div>
   )
 }

--- a/components/TopScrollButton.tsx
+++ b/components/TopScrollButton.tsx
@@ -1,0 +1,17 @@
+'use client'
+
+import { buttonVariants } from '@/components/ui/button'
+
+export function TopScrollButton() {
+    return (
+        <div className="flex justify-center mt-10">
+            <button
+                type="button"
+                className={`${buttonVariants({ variant: 'outline' })} h-11 border-black`}
+                onClick={() => window.scrollTo({ top: 0, behavior: 'smooth' })}
+            >
+                トップに戻る
+            </button>
+        </div>
+    )
+}


### PR DESCRIPTION
- [issue#38](https://github.com/digitaldemocracy2030/website/issues/38)
- [issue#90](https://github.com/digitaldemocracy2030/website/issues/90)

- 変更内容
1. 広聴AIページに使い方ボタンを作成
2. ページトップに戻るボタンを追加
3. Googleフォームのリンクを"https://docs.google.com/forms/d/e/1FAIpQLScytDD9cdYwcl_Gsr0qal-Op7mpXaQzK3KGTk_FsahY5FkU9w/viewform?usp=header" に貼り替えました。

- 修正後

1. 
![スクリーンショット 2025-05-24 13 16 14（2）](https://github.com/user-attachments/assets/9c8f505f-a8dd-49a6-8073-a10daf1700e1)
 2. 

![スクリーンショット 2025-05-24 13 16 23（2）](https://github.com/user-attachments/assets/ce694e9d-722f-4c62-a8c4-e6aba9846b38)





