### PR TITLE
[広聴AI]ページレスポンシブ対応

### DIFF
--- a/app/kouchou-ai/page.tsx
+++ b/app/kouchou-ai/page.tsx
@@ -85,7 +85,7 @@ export default async function Page() {
             また、ネット上のみで情報収集をするのではなく、タウンミーティングや直接的なヒアリングなど情報源を多様化することが有益です。ブロードリスニングの対象データとしても、電話やオフラインで寄せられる多様な声を集めることは重要であり、様々な声を集めた上で全体像を可視化することで、よりよい意思決定を支える仕組みになると考えています。
           </p>
         </section>
-        <div className="flex gap-4 mt-20">
+        <div className="flex flex-wrap gap-4 mt-20">
           <Link
             href="https://www.figma.com/deck/0B55u8rxDjjjpRJbNUEP0Z/%F0%9F%A7%AD-Brand-Compass?node-id=28-1217&t=iTF8igZOaTbM8DMn-1"
             className={`${buttonVariants({ variant: 'outline' })} h-11 border-black`}
@@ -106,7 +106,10 @@ export default async function Page() {
             </div>
             <NavigateNextIcon />
           </Link>
-          <Link href="/history" className={`${buttonVariants()} h-11`}>
+          <Link
+            href="/history"
+            className={`${buttonVariants()} h-11 sm:w-auto`}
+          >
             <span></span>
             直近の活動
             <NavigateNextIcon />


### PR DESCRIPTION
- [issue#103](https://github.com/digitaldemocracy2030/website/issues/103)

- 変更内容
[広聴AI]ページの[直近の活動>]がスマホ画面で見ると右にはみ出しているのを修正

- 修正後(ブラウザ画面)
![スクリーンショット 2025-05-24 14 58 16 2](https://github.com/user-attachments/assets/b65a8406-3089-4b00-acab-66134a3466b5)

- 修正後(モバイル画面)
![スクリーンショット 2025-05-24 14 58 08（2）](https://github.com/user-attachments/assets/317246b3-4640-4d63-8b5c-459d3697cafe)
