### PR TITLE
Fix lint on PR create, edit, sync, reopen

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,38 @@
+name: Lint
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+# Sets permissions of the GITHUB_TOKEN to allow fixing lint issues
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  lint:
+    name: Lint Code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: 'npm'
+      
+      - name: Install dependencies
+        run: npm ci
+      
+      - name: Run Lint Action
+        uses: wearerequired/lint-action@v2
+        with:
+          eslint: true
+          eslint_extensions: "js,jsx,ts,tsx"
+          auto_fix: true
+          commit: true
+          git_name: "Lint Action"
+          git_email: "lint-action@github.com"
+          commit_message: "Fix code style issues with ESLint"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,5 +33,5 @@ jobs:
           auto_fix: true
           commit: true
           git_name: "Lint Action"
-          git_email: "lint-action@github.com"
+          git_email: "lint-action@github.com" 
           commit_message: "Fix code style issues with ESLint"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,9 +2,8 @@ name: Lint
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    types: [opened, edited, synchronize, reopened]
 
-# Sets permissions of the GITHUB_TOKEN to allow fixing lint issues
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -33,5 +33,5 @@ jobs:
           auto_fix: true
           commit: true
           git_name: "Lint Action"
-          git_email: "lint-action@github.com" 
+          git_email: "lint-action@github.com"
           commit_message: "Fix code style issues with ESLint"

--- a/hooks/use-mobile.ts
+++ b/hooks/use-mobile.ts
@@ -1,4 +1,4 @@
-import * as React from "react"
+import * as React from 'react'
 
 const MOBILE_BREAKPOINT = 768
 
@@ -10,9 +10,9 @@ export function useIsMobile() {
     const onChange = () => {
       setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
     }
-    mql.addEventListener("change", onChange)
+    mql.addEventListener('change', onChange)
     setIsMobile(window.innerWidth < MOBILE_BREAKPOINT)
-    return () => mql.removeEventListener("change", onChange)
+    return () => mql.removeEventListener('change', onChange)
   }, [])
 
   return !!isMobile

--- a/scripts/reorganize-markdown.js
+++ b/scripts/reorganize-markdown.js
@@ -1,85 +1,85 @@
-const fs = require('fs');
-const path = require('path');
-const { execSync } = require('child_process');
+const fs = require('fs')
+const path = require('path')
+const { execSync } = require('child_process')
 
-const markdownDir = path.join(process.cwd(), 'markdown');
+const markdownDir = path.join(process.cwd(), 'markdown')
 
-const historyDir = path.join(markdownDir, 'history');
+const historyDir = path.join(markdownDir, 'history')
 if (!fs.existsSync(historyDir)) {
-  fs.mkdirSync(historyDir, { recursive: true });
+  fs.mkdirSync(historyDir, { recursive: true })
 }
 
 const getDateFromGit = (filename) => {
   try {
-    const dateStr = execSync(`git log --name-only --pretty=format:"%ad" --date=short -- ${path.join('markdown', filename)} | head -1`).toString().trim();
-    return dateStr.replace(/-/g, '');
+    const dateStr = execSync(`git log --name-only --pretty=format:"%ad" --date=short -- ${path.join('markdown', filename)} | head -1`).toString().trim()
+    return dateStr.replace(/-/g, '')
   } catch (error) {
-    return '20250404';
+    return '20250404'
   }
-};
+}
 
 const getWeekFromFilename = (filename) => {
   if (filename.startsWith('slack') || filename.startsWith('github')) {
-    const match = filename.match(/(?:slack|github)(\d+)w/);
-    return match && match[1] ? parseInt(match[1], 10) : 0;
+    const match = filename.match(/(?:slack|github)(\d+)w/)
+    return match && match[1] ? parseInt(match[1], 10) : 0
   }
-  return 0;
-};
+  return 0
+}
 
 const getProjectFromFilename = (filename) => {
   if (filename.startsWith('github')) {
-    const match = filename.match(/github\d+w-(.+)\.md/);
-    return match && match[1] ? match[1] : 'unknown';
+    const match = filename.match(/github\d+w-(.+)\.md/)
+    return match && match[1] ? match[1] : 'unknown'
   }
-  return null;
-};
+  return null
+}
 
 const moveFiles = () => {
-  const files = fs.readdirSync(markdownDir);
+  const files = fs.readdirSync(markdownDir)
   
-  const weeklyFiles = {};
+  const weeklyFiles = {}
   
   files.forEach(file => {
     if ((file.startsWith('slack') || file.startsWith('github')) && file.endsWith('.md')) {
-      const week = getWeekFromFilename(file);
+      const week = getWeekFromFilename(file)
       if (!weeklyFiles[week]) {
-        weeklyFiles[week] = [];
+        weeklyFiles[week] = []
       }
-      weeklyFiles[week].push(file);
+      weeklyFiles[week].push(file)
     }
-  });
+  })
   
   Object.keys(weeklyFiles).forEach(week => {
     if (week > 0) {
-      const firstFile = weeklyFiles[week][0];
-      const date = getDateFromGit(firstFile);
+      const firstFile = weeklyFiles[week][0]
+      const date = getDateFromGit(firstFile)
       
-      const weekDir = path.join(historyDir, `week${week}_${date}`);
+      const weekDir = path.join(historyDir, `week${week}_${date}`)
       if (!fs.existsSync(weekDir)) {
-        fs.mkdirSync(weekDir, { recursive: true });
+        fs.mkdirSync(weekDir, { recursive: true })
       }
       
       weeklyFiles[week].forEach(file => {
-        const sourcePath = path.join(markdownDir, file);
+        const sourcePath = path.join(markdownDir, file)
         
-        let targetFilename;
+        let targetFilename
         if (file.startsWith('slack')) {
-          targetFilename = 'slack.md';
+          targetFilename = 'slack.md'
         } else if (file.startsWith('github')) {
-          const project = getProjectFromFilename(file);
-          targetFilename = `${project}.md`;
+          const project = getProjectFromFilename(file)
+          targetFilename = `${project}.md`
         }
         
         if (targetFilename) {
-          const targetPath = path.join(weekDir, targetFilename);
-          fs.copyFileSync(sourcePath, targetPath);
-          console.log(`Copied ${sourcePath} to ${targetPath}`);
+          const targetPath = path.join(weekDir, targetFilename)
+          fs.copyFileSync(sourcePath, targetPath)
+          console.log(`Copied ${sourcePath} to ${targetPath}`)
         }
-      });
+      })
     }
-  });
+  })
   
-  console.log('File reorganization completed.');
-};
+  console.log('File reorganization completed.')
+}
 
-moveFiles();
+moveFiles()


### PR DESCRIPTION
## 目的

- エンジニア以外にとってコンテンツを編集しやすくする
- レビュアーの差し戻しコストを減らす

## 変更点の概要

- `.github/workflows/lint.yml` : `wearerequired/lint-action`を使って自動的に lint errors を fix する
- `.github/workflows/lint.yml` 以外 : 上記の処理によって自動的に fix されたファイル（本PRの2つ目のcommit分です）

## 要検討事項

https://github.com/marketplace/actions/lint-action#limitations
`.github/workflows/`以下のファイルでlintエラーがあると、fixしようとして権限不足で（開発者側のリポジトリの）Actionsがエラーになります。これを回避するためにフォルダごとlint対象外にするという方法があるのですが、ここをいじるのは開発者だけなので、むしろエラーになった上で直すように促したいです。なので対象外にはしませんでした。