### PR TITLE
Slackへの招待リンクがスマホやタブレットではエラーになっている可能性があったので修正。

### DIFF
--- a/app/co-creation/page.tsx
+++ b/app/co-creation/page.tsx
@@ -33,7 +33,7 @@ export default async function Page() {
             <h4 className="text-xl">Slackに参加する</h4>
             <p className="mt-4">参加して様子を見てみましょう。</p>
             <Link
-              href="https://join.slack.com/t/w1740803485-clv347541/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA"
+              href="https://join.slack.com/t/dd2030/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA"
               className={`${buttonVariants()} h-11 mt-4`}
               target="_blank"
             >

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       // },
       sameAs: [
         'https://github.com/digitaldemocracy2030',
-        'https://join.slack.com/t/w1740803485-clv347541/shared_invite/zt-32haul96s-Iopa_ET_YcqXWlpzpqABRA',
+        'https://join.slack.com/t/dd2030/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA',
       ],
     },
     {
@@ -81,7 +81,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
           name: '一般市民も参加できますか？',
           acceptedAnswer: {
             '@type': 'Answer',
-            text: 'はい、どなたでもご参加いただけます。<br/ ><a href="https://join.slack.com/t/w1740803485-clv347541/shared_invite/zt-32haul96s-Iopa_ET_YcqXWlpzpqABRA">こちらのSlack</a>からご参加下さい。',
+            text: 'はい、どなたでもご参加いただけます。<br/ ><a href="https://join.slack.com/t/dd2030/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA">こちらのSlack</a>からご参加下さい。',
           },
         },
       ],

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -7,7 +7,7 @@ export function Footer() {
       <div className="sm:flex justify-center pt-6">
         <div>
           <Link
-            href="https://join.slack.com/t/w1740803485-clv347541/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA"
+            href="https://join.slack.com/t/dd2030/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA"
             className={`${buttonVariants({ variant: 'ghost' })} h-11`}
             target="_blank"
           >

--- a/components/HowTo.tsx
+++ b/components/HowTo.tsx
@@ -40,7 +40,7 @@ export function HowTo() {
             </Card.Description>
           </Card.Body>
           <Card.Footer gap="2">
-            <Link href={'https://join.slack.com/t/w1740803485-clv347541/shared_invite/zt-31oaoavwl-PUQLXlFFLL2KE5jXzR6IwA'} target={'_blank'}>
+            <Link href={'https://join.slack.com/t/dd2030/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA'} target={'_blank'}>
               <Button variant="solid">Slack に参加する</Button>
             </Link>
           </Card.Footer>


### PR DESCRIPTION
## 概要
* iPadで公式サイトのSlack参加を押した際にエラーになる
* PCからは問題無く表示できる
* 仮説では、タブレットやスマホのアプリだと、URLのワークスペースが厳密に一致していないとエラーになるのかも

## 修正内容
* Webサイト内のSlack招待URLを、モアイさんから送って貰ったもので修正

## 備考
* ついでに、今画面として表示されていないと思われる箇所の招待URLも一緒に修正