### PR TITLE
Footerコンポーネントから不要なspanを削除

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -11,7 +11,6 @@ export function Footer() {
             className={`${buttonVariants({ variant: 'ghost' })} h-11`}
             target="_blank"
           >
-            <span></span>
             Slackに参加
           </Link>
         </div>
@@ -21,7 +20,6 @@ export function Footer() {
             className={`${buttonVariants({ variant: 'ghost' })} h-11`}
             target="_blank"
           >
-            <span></span>
             GitHub
           </Link>
         </div>
@@ -31,19 +29,16 @@ export function Footer() {
             className={`${buttonVariants({ variant: 'ghost' })} h-11`}
             target="_blank"
           >
-            <span></span>
             Note
           </Link>
         </div>
         <div>
           <Link href="/policies/privacy" className={`${buttonVariants({ variant: 'ghost' })} h-11`}>
-            <span></span>
             プライバシーポリシー
           </Link>
         </div>
         <div>
           <Link href="/policies/terms" className={`${buttonVariants({ variant: 'ghost' })} h-11`}>
-            <span></span>
             利用規約
           </Link>
         </div>


### PR DESCRIPTION
Footer に 空の spanタグが入っていますが、不要かと思うので削除しました
<img width="592" height="116" alt="スクリーンショット 2025-07-26 午後8 01 21" src="https://github.com/user-attachments/assets/8d25d99b-0f83-40b9-8e4f-ebf03da2a39b" />

これにより少しリンク同士の間隔が狭まりましたが、問題ないレベルかと思います。
<img width="582" height="145" alt="スクリーンショット 2025-07-26 午後8 03 59" src="https://github.com/user-attachments/assets/e504b2d3-5218-4b82-afb8-0971edf8158c" />
