### PR TITLE
feat: HSTS の設定を追加

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -15,6 +15,19 @@ const nextConfig: NextConfig = {
   skipTrailingSlashRedirect: true,
   skipMiddlewareUrlNormalize: true,
   basePath: process.env.NEXT_PUBLIC_PR_NUMBER ? `/pr-preview/pr-${process.env.NEXT_PUBLIC_PR_NUMBER}` : '',
+  headers: async () => {
+    return [
+      {
+        source: '/(.*)',
+        headers: [
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=63072000; includeSubDomains; preload',
+          },
+        ],
+      },
+    ]
+  },
 }
 
 export default nextConfig


### PR DESCRIPTION
よりセキュアにするため HSTS の設定を追加
- <https://nextjs.org/docs/pages/api-reference/config/next-config-js/headers>
-  <https://developer.mozilla.org/ja/docs/Web/HTTP/Reference/Headers/Strict-Transport-Security>

http を使っている箇所はないかと思うので、下記で設定
- max-age は 2年が推奨されているので 63072000 に設定
- includeSubDomains あり
- preload あり
<img width="898" height="499" alt="スクリーンショット 2025-08-09 午前10 55 46" src="https://github.com/user-attachments/assets/0cabb0df-cfe5-4ba1-a287-1d762607d468" />

<https://developer.chrome.com/docs/lighthouse/best-practices/has-hsts?hl=ja>


