### PR TITLE
chore: marked を v15 から v16 へアップデート

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "github-markdown-css": "^5.8.1",
         "gray-matter": "^4.0.3",
         "lucide-react": "^0.488.0",
-        "marked": "^15.0.7",
+        "marked": "^16.1.2",
         "next-mdx-remote": "^5.0.0",
         "postcss": "^8.5.3",
         "react": "^19.1.0",
@@ -7335,15 +7335,15 @@
       }
     },
     "node_modules/marked": {
-      "version": "15.0.7",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.7.tgz",
-      "integrity": "sha512-dgLIeKGLx5FwziAnsk4ONoGwHwGPJzselimvlVskE9XLN4Orv9u2VA3GWw/lYUqjfA0rUT/6fqKwfZJapP9BEg==",
+      "version": "16.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.1.2.tgz",
+      "integrity": "sha512-rNQt5EvRinalby7zJZu/mB+BvaAY2oz3wCuCjt1RDrWNpS1Pdf9xqMOeC9Hm5adBdcV/3XZPJpG58eT+WBc0XQ==",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/math-intrinsics": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "github-markdown-css": "^5.8.1",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.488.0",
-    "marked": "^15.0.7",
+    "marked": "^16.1.2",
     "next-mdx-remote": "^5.0.0",
     "postcss": "^8.5.3",
     "react": "^19.1.0",


### PR DESCRIPTION
marked を v15 から v16 へアップデート
- <https://github.com/markedjs/marked/releases>
  - `npm run build` でエラーにならないこと、`npm run dev` で動かしてみて問題なく表示されていることを確認済み
 
node v20 未満はサポート対象外になりましたが、 node v20未満は既にEOLであり、  
使用していないかと思うので問題なしと判断しています