### PR TITLE
Slack招待リンクが切れてたので一旦更新

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -53,7 +53,7 @@ export default function RootLayout({ children }: Readonly<{ children: React.Reac
       // },
       sameAs: [
         'https://github.com/digitaldemocracy2030',
-        'https://join.slack.com/t/dd2030/shared_invite/zt-35bjj11ms-OQtx4Lu08LJ4OqWiRAgNrA',
+        'https://join.slack.com/t/dd2030/shared_invite/zt-3bwgwcbzk-yFCRN81QhQM1WN2Q~R12UQ',
       ],
     },
     {


### PR DESCRIPTION
とりあえず私の権限で発行できる期限30日の招待リンクで差し替えます。
9月17日あたりに失効する予定です。