### PR TITLE
定期的に "プロジェクトの歴史" を更新する GitHub workflow を追加

### DIFF
--- a/.github/workflows/weekly-summary.yml
+++ b/.github/workflows/weekly-summary.yml
@@ -1,0 +1,180 @@
+name: Weekly Summary
+
+permissions:
+  contents: write
+  pull-requests: write
+
+on:
+  schedule:
+    - cron: '30 03 * * 3'  # oss_weekly_reporter が 毎週水曜 12:00 JST に実行されるため、それ以降の 12:30 JST に実行する
+  workflow_dispatch:       # 手動実行も可能
+
+jobs:
+  generate-summary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+    - name: Set up GitHub CLI
+      run: |
+        echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+        gh auth status || echo "GitHub CLIの認証に問題があります"
+  
+    - name: Checkout dd2030-website repository
+      uses: actions/checkout@v4
+      with:
+        path: dd2030-website
+        ref: main
+        fetch-depth: 0
+
+    - name: Checkout oss_weekly_reporter repository (main branch)
+      uses: actions/checkout@v4
+      with:
+        repository: nishio/oss_weekly_reporter
+        ref: main
+        path: oss_weekly_reporter
+        fetch-depth: 0
+
+    - name: Get latest data directory (fetch data branch first)
+      id: get_latest_data
+      run: |
+        set -euo pipefail
+
+        # fetch remote data branch into local branch named 'data'
+        git -C oss_weekly_reporter fetch origin data:data
+
+        latest_dir=$(git -C oss_weekly_reporter ls-tree -r --name-only data \
+          | grep -E '^data/' \
+          | awk -F'/' '{print $2}' \
+          | sort -u \
+          | tail -n1 || true)
+
+        if [ -z "${latest_dir:-}" ]; then
+          echo "ERROR: no data directories found in oss_weekly_reporter:data" >&2
+          exit 1
+        fi
+
+        latest_path="data/${latest_dir}"
+        echo "latest_data_dir=${latest_path}" >> $GITHUB_ENV
+        echo "Latest data directory: ${latest_path}"
+
+    - name: Checkout only the latest data directory from data branch
+      run: |
+        set -euo pipefail
+
+        latest="${{ env.latest_data_dir }}"
+        if [ -z "$latest" ]; then
+          echo "env.latest_data_dir is empty" >&2
+          exit 1
+        fi
+
+        echo "Checking out ${latest} from local branch 'data' into oss_weekly_reporter/"
+        # checkout the specific path from the local 'data' branch fetched earlier
+        git -C oss_weekly_reporter checkout data -- "$latest"
+
+        echo "Checked out:"
+        ls -la "oss_weekly_reporter/${latest}" || true
+
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.10'
+
+    - name: Cache pip
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/pip
+        key: pip-cache-${{ runner.os }}-py-${{ hashFiles('**/oss_weekly_reporter/pyproject.toml', '**/oss_weekly_reporter/requirements.txt') }}
+        restore-keys: |
+          pip-cache-${{ runner.os }}-py-
+
+    - name: Install dependencies (oss_weekly_reporter)
+      working-directory: oss_weekly_reporter
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e .
+
+    - name: Ensure OPENAI_API_KEY is set
+      run: |
+        set -euo pipefail
+        if [ -z "${{ secrets.OPENAI_API_KEY }}" ]; then
+          echo "ERROR: secrets.OPENAI_API_KEY is not set. Aborting." >&2
+          exit 1
+        fi
+        echo "OPENAI_API_KEY is set (secret value is not displayed)."
+
+    - name: Generate OpenAI summary for Slack data
+      working-directory: oss_weekly_reporter
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: |
+        python -m src.call_openai_api slack --all-summary
+
+    - name: Generate OpenAI summary for GitHub data (kouchou-ai)
+      working-directory: oss_weekly_reporter
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: |
+        python -m src.call_openai_api github --repo "digitaldemocracy2030/kouchou-ai" --prompt-file "./prompts/kouchou_prompt.txt"
+
+    - name: Generate OpenAI summary for GitHub data (idobata)
+      working-directory: oss_weekly_reporter
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: |
+         python -m src.call_openai_api github --repo "digitaldemocracy2030/idobata" --prompt-file "./prompts/idobata_prompt.txt"
+
+    - name: Generate OpenAI summary for GitHub data (website)
+      working-directory: oss_weekly_reporter
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: |
+        python -m src.call_openai_api github --repo "digitaldemocracy2030/website" --prompt-file "./prompts/website_prompt.txt"
+
+    - name: Generate OpenAI summary for GitHub data (polimoney)
+      working-directory: oss_weekly_reporter
+      env:
+        OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      run: |
+        python -m src.call_openai_api github --repo "digitaldemocracy2030/polimoney" --prompt-file "./prompts/polimoney_prompt.txt"
+
+    - name: Copy summary data to working directory
+      run: |
+        # env.latest_data_dir 例: data/2025-08-20_to_2025-08-27
+        name=$(basename "${{ env.latest_data_dir }}")   # -> 2025-08-20_to_2025-08-27
+        # 末尾の終了日を YYYYMMDD に変換
+        end_date=$(echo "$name" | sed -E 's/.*_to_([0-9]{4})-([0-9]{2})-([0-9]{2})$/\1\2\3/')
+
+        git -C dd2030-website fetch origin main:refs/remotes/origin/main
+
+        # origin/main の markdown/history を見て最後の weekN を決定
+        last_weekly_num=$(git -C dd2030-website ls-tree -r --name-only origin/main \
+          | grep -E '^markdown/history/' \
+          | awk -F'/' '{print $3}' \
+          | grep -E '^week[0-9]+' \
+          | sed -E 's/^week([0-9]+)_.*/\1/' \
+          | sort -n \
+          | tail -n1 || true)
+        last_weekly_num=${last_weekly_num:-0}
+        next_weekly_num=$((last_weekly_num + 1))
+        dest="dd2030-website/markdown/history/week${next_weekly_num}_${end_date}"
+        mkdir -p "$dest"
+        cp -r oss_weekly_reporter/${{ env.latest_data_dir }}/ai_reports/* "$dest/"
+        ls -l "$dest"
+
+        echo "next_weekly_num=${next_weekly_num}" >> $GITHUB_ENV
+        echo "end_date=${end_date}" >> $GITHUB_ENV
+
+    - name: Create Pull Request with summaries
+      uses: peter-evans/create-pull-request@v3
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        path: dd2030-website
+        branch: week${{ env.next_weekly_num }}
+        base: main
+        title: "Week${{ env.next_weekly_num }} Summary Update"
+        body: "Auto-generated weekly summaries for week${{ env.next_weekly_num }}"
+        commit-message: "Week${{ env.next_weekly_num }} Summary Update"
+        add-paths: |
+          markdown/history/week${{ env.next_weekly_num }}_${{ env.end_date }}/*.md
+        draft: true


### PR DESCRIPTION
定期的に[プロジェクトの歴史](https://dd2030.org/history) の slack, github の週ごとのサマリーを更新するようにします

Slack, GitHub からのデータの抽出までは[このリポジトリのワークフロー](https://github.com/nishio/oss_weekly_reporter/actions/runs/17256391901/workflow)にて定期的に取得されているため、そのデータを使って要約を生成し、このリポジトリにPR(draft) を提出するようにします。

- dd2030 が費用負担する OPENAI_API_KEY を利用（リポジトリに設定）
- 毎週水曜 12:30 JSTに実行（[元データの処理が毎週水曜 12:00 JST に実行される](https://github.com/nishio/oss_weekly_reporter/blob/6dd583d0492f1ff029d6dc5a837f8530fea1e93d/.github/workflows/weekly-report.yml#L6)ため、それ以降の時間を指定）

## 動作確認
自分のリポジトリで試してみました
- GitHub Actions: https://github.com/shingo-ohki/dd2030-website/actions/runs/17403185245
- 作成されたPR: https://github.com/shingo-ohki/dd2030-website/pull/3/files