### PR TITLE
トップページのお知らせ一覧の順序のソート順を修正

### DIFF
--- a/src/index.vto
+++ b/src/index.vto
@@ -133,7 +133,7 @@ description: デジタル民主主義2030プロジェクトポータルサイト
     <div class="flex gap-4 mt-4"></div>
     <h2 class="text-3xl mt-5 pb-4">最新のお知らせ</h2>
     <ul class="space-y-4 mt-4">
-      {{ for entry of search.pages("type=topics", "date=desc", 3) }}
+      {{ for entry of search.pages("type=topics draft!=true", "publish_on=desc", 3) }}
         <li class="pb-4">
           <a href="{{ entry.url |> url }}" class="text-xl text-blue-600 hover:underline">
             {{ entry.title }}


### PR DESCRIPTION
ef3ddf2 の漏れ

## 変更前
<img width="707" height="477" alt="スクリーンショット 2026-01-04 13 16 42" src="https://github.com/user-attachments/assets/6013528e-f3c0-40ac-abe1-1516eef3f07e" />

## 変更後
<img width="708" height="484" alt="スクリーンショット 2026-01-04 13 17 44" src="https://github.com/user-attachments/assets/e8a5fb55-9dc8-46c1-b8c7-7fcffd15edfe" />


